### PR TITLE
Add release of connection to underlying amqp resource

### DIFF
--- a/src/event-bus/index.ts
+++ b/src/event-bus/index.ts
@@ -26,6 +26,8 @@ export interface EventSubscriber {
 export interface EventBus extends EventPublisher, EventSubscriber {
     // This needs to be documented better / commented better. What are eventDefinitions? how is a serviceName going to be used?
     init(eventDefinitions: string[], serviceName: string): Promise<this>;
+
+    destroy(): Promise<void>;
 }
 // This isn't generic enough
 export interface EventConfig {

--- a/src/mock-event-bus/index.ts
+++ b/src/mock-event-bus/index.ts
@@ -60,4 +60,8 @@ export class MockEventBus implements EventBus {
     ): Promise<void> {
         this.queues.get().set(`${eventType}`, handler);
     }
+
+    public async destroy(): Promise<void> {
+        return Promise.resolve();
+    }
 }

--- a/src/rabbit-event-bus/amqp-connector.ts
+++ b/src/rabbit-event-bus/amqp-connector.ts
@@ -14,6 +14,7 @@ export default class AMQPConnector {
     private serviceName = 'unknown-service';
     private subscriptions: Array<Subscription<object>>;
     private connection: Connection;
+    private destroyed = false;
 
     public constructor(
         url: string,
@@ -66,6 +67,14 @@ export default class AMQPConnector {
             return connection;
         } catch (e) {
             throw new Error('Connection failed');
+        }
+    }
+
+    public async destroy(): Promise<void> {
+        this.destroyed = true;
+
+        if (this.connection) {
+            return this.connection.close();
         }
     }
 
@@ -153,7 +162,9 @@ export default class AMQPConnector {
     }
 
     private disconnected(): void {
-        this.externalConnector.send({ newState: 'NOT_CONNECTED' });
+        if (!this.destroyed) {
+            this.externalConnector.send({ newState: 'NOT_CONNECTED' });
+        }
     }
 
     private connected(): void {

--- a/src/rabbit-event-bus/index.test.ts
+++ b/src/rabbit-event-bus/index.test.ts
@@ -8,6 +8,19 @@ jest.mock('../logger');
 jest.mock('./amqp-connector');
 
 describe('AMQP Connection Manager', () => {
+    describe('destory', () => {
+        it('calls connector destroy method', async () => {
+            const destroyMock = jest.fn();
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            (AMQPConnector as jest.Mock).mockImplementation(() => ({ destroy: destroyMock }));
+            const manager = await new RabbitEventBus({ url: '' }).init([], '');
+
+            await manager.destroy();
+
+            expect(destroyMock).toHaveBeenCalledTimes(1);
+        });
+    });
+
     describe('behaviour in a good connection state', () => {
         it('forwards messages to a connector', async () => {
             const publishMock = jest.fn(async () => true);

--- a/src/rabbit-event-bus/index.ts
+++ b/src/rabbit-event-bus/index.ts
@@ -42,6 +42,12 @@ export default class RabbitEventBus implements EventBus, ConnectionOwner {
         return this;
     }
 
+    public async destroy(): Promise<void> {
+        if (this.connector) {
+            this.connector.get().destroy();
+        }
+    }
+
     public onConnect(): void {
         this.queue.publishQueue();
     }
@@ -56,8 +62,6 @@ export default class RabbitEventBus implements EventBus, ConnectionOwner {
     }
 
     private connect(): void {
-        // logger.debug('attemptingConnection');
-        // Should I debounce this?
         this.connector = Some(
             new AMQPConnector(
                 this.url,


### PR DESCRIPTION
Closes #12 

- Added `destroy` method to EventBus interface
- Updated RabbitEventBus to close underlying RabbitMQ connection when `destroy` called
- Updated unit tests