### PR TITLE
Move connection logic out of constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "husky": {
     "hooks": {
+      "pre-push": "yarn test",
       "pre-commit": "yarn lint"
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libero/event-bus",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn lint",
-      "pre-push": "yarn test"
+      "pre-commit": "yarn lint"
     }
   },
   "author": "libero-npm@elifesciences.org",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "yarn test",
-      "pre-commit": "yarn lint"
+      "pre-commit": "yarn lint",
+      "pre-push": "yarn test"
     }
   },
   "author": "libero-npm@elifesciences.org",

--- a/src/rabbit-event-bus/amqp-connector.test.ts
+++ b/src/rabbit-event-bus/amqp-connector.test.ts
@@ -41,8 +41,8 @@ describe('AMQP connector', () => {
 
             const sender = jest.fn();
             const receiver = async (): Promise<StateChange> => ({} as StateChange);
-            const connector = new AMQPConnector([sender, receiver], 'service');
-            await connector.setup(url, [], []);
+            const connector = new AMQPConnector(url, [sender, receiver], 'service');
+            await connector.setup([], []);
 
             await flushPromises();
             expect(connect).toHaveBeenCalledTimes(1);
@@ -57,8 +57,8 @@ describe('AMQP connector', () => {
             const sender = jest.fn();
             const receiver = async (): Promise<StateChange> => ({} as StateChange);
 
-            const connector = new AMQPConnector([sender, receiver], 'service');
-            await connector.setup(url, [], []);
+            const connector = new AMQPConnector(url, [sender, receiver], 'service');
+            await connector.setup([], []);
 
             await flushPromises();
             expect(sender).toHaveBeenCalledTimes(1);
@@ -70,8 +70,8 @@ describe('AMQP connector', () => {
             const mockConnection = makeConnection(mockChannel);
 
             (connect as jest.Mock).mockImplementation(async (): Promise<Connection> => mockConnection);
-            const connector = new AMQPConnector(channel(), 'service');
-            connector.setup(url, ['test:event'], []);
+            const connector = new AMQPConnector(url, channel(), 'service');
+            connector.setup(['test:event'], []);
 
             await flushPromises();
             expect(mockChannel.assertExchange).toHaveBeenCalledTimes(1);
@@ -84,8 +84,8 @@ describe('AMQP connector', () => {
             const eventType = 'test:event';
 
             (connect as jest.Mock).mockImplementation(async (): Promise<Connection> => mockConnection);
-            const connector = new AMQPConnector(channel(), 'service');
-            connector.setup(url, [], [{ eventType, handler: jest.fn() }]);
+            const connector = new AMQPConnector(url, channel(), 'service');
+            connector.setup([], [{ eventType, handler: jest.fn() }]);
 
             await flushPromises();
             expect(mockChannel.assertQueue).toHaveBeenCalledTimes(1);
@@ -110,8 +110,8 @@ describe('AMQP connector', () => {
 
             const sender = jest.fn();
             const receiver = async (): Promise<StateChange> => ({} as StateChange);
-            const connector = new AMQPConnector([sender, receiver], 'service');
-            await connector.setup(url, [], []);
+            const connector = new AMQPConnector(url, [sender, receiver], 'service');
+            await connector.setup([], []);
 
             await flushPromises();
             connector.destroy();
@@ -134,8 +134,8 @@ describe('AMQP connector', () => {
                 payload: { data: 'payload' },
             };
             (connect as jest.Mock).mockImplementation(async (): Promise<Connection> => mockConnection);
-            const connector = new AMQPConnector(channel(), 'service');
-            connector.setup(url, ['test:event'], []);
+            const connector = new AMQPConnector(url, channel(), 'service');
+            connector.setup(['test:event'], []);
             // we need to wait for connection to be stored before we can publish
             await flushPromises();
             await connector.publish(event as Event);
@@ -164,8 +164,8 @@ describe('AMQP connector', () => {
             const mockConnection = makeConnection(mockChannel);
 
             (connect as jest.Mock).mockImplementation(async (): Promise<Connection> => mockConnection);
-            const connector = new AMQPConnector(channel(), 'service');
-            await connector.setup(url, [], []);
+            const connector = new AMQPConnector(url, channel(), 'service');
+            await connector.setup([], []);
 
             await flushPromises();
             await connector.subscribe('test:event', jest.fn());
@@ -194,8 +194,8 @@ describe('AMQP connector', () => {
             const mockConnection = makeConnection(mockChannel);
 
             (connect as jest.Mock).mockImplementation(async (): Promise<Connection> => mockConnection);
-            const connector = new AMQPConnector(channel(), 'service');
-            await connector.setup(url, [], []);
+            const connector = new AMQPConnector(url, channel(), 'service');
+            await connector.setup([], []);
             const handler = jest.fn().mockImplementation(async () => Promise.resolve(true));
 
             await flushPromises();
@@ -231,8 +231,8 @@ describe('AMQP connector', () => {
             const mockConnection = makeConnection(mockChannel);
 
             (connect as jest.Mock).mockImplementation(async (): Promise<Connection> => mockConnection);
-            const connector = new AMQPConnector(channel(), 'service');
-            await connector.setup(url, [], []);
+            const connector = new AMQPConnector(url, channel(), 'service');
+            await connector.setup([], []);
             const handler = jest.fn().mockImplementation(async () => Promise.resolve());
 
             await flushPromises();
@@ -272,8 +272,8 @@ describe('AMQP connector', () => {
         const mockConnection = makeConnection(mockChannel);
 
         (connect as jest.Mock).mockImplementation(async (): Promise<Connection> => mockConnection);
-        const connector = new AMQPConnector(channel(), 'service');
-        await connector.setup(url, [], []);
+        const connector = new AMQPConnector(url, channel(), 'service');
+        await connector.setup([], []);
         const handler = jest.fn().mockImplementation(async () => Promise.resolve());
 
         await flushPromises();

--- a/src/rabbit-event-bus/amqp-connector.test.ts
+++ b/src/rabbit-event-bus/amqp-connector.test.ts
@@ -3,7 +3,6 @@ import * as flushPromises from 'flush-promises';
 import AMQPConnector from './amqp-connector';
 import { StateChange } from './types';
 import { channel } from 'rs-channel-node';
-// import { Event } from 'event-bus';
 import { InfraLogger as logger } from '../logger';
 import { EventUtils } from './event-utils';
 import { Event } from 'index';

--- a/src/rabbit-event-bus/amqp-connector.test.ts
+++ b/src/rabbit-event-bus/amqp-connector.test.ts
@@ -5,7 +5,7 @@ import { StateChange } from './types';
 import { channel } from 'rs-channel-node';
 import { InfraLogger as logger } from '../logger';
 import { EventUtils } from './event-utils';
-import { Event } from 'index';
+import { Event } from '../event-bus/index';
 
 jest.mock('amqplib');
 jest.mock('../logger');

--- a/src/rabbit-event-bus/amqp-connector.ts
+++ b/src/rabbit-event-bus/amqp-connector.ts
@@ -70,13 +70,14 @@ export default class AMQPConnector {
                     logger.fatal(`Can't create subscriber queues for: ${this.serviceName} using event: ${eventType}`);
                 });
         } else {
-            logger.warn("No CONTAINER, can't subscribe, trying again soon!");
+            const retryIn = 1000;
+            logger.warn(`No connection, can't subscribe. Trying again in ${retryIn} milliseconds`);
             // Do we want to handle reconnects &/or retries here?
             return new Promise(resolve =>
                 setTimeout(async () => {
                     await this.subscribe(eventType, handler);
                     resolve();
-                }, 1000),
+                }, retryIn),
             );
         }
     }

--- a/src/rabbit-event-bus/amqp-connector.ts
+++ b/src/rabbit-event-bus/amqp-connector.ts
@@ -71,7 +71,8 @@ export default class AMQPConnector {
                 });
         } else {
             const retryIn = 1000;
-            logger.warn(`No connection, can't subscribe. Trying again in ${retryIn} milliseconds`);
+            const hostname = this.url.indexOf('@') > -1 ? this.url.split('@')[1] : this.url;
+            logger.warn(`No connection, can't subscribe to ${hostname}. Trying again in ${retryIn} milliseconds`);
             // Do we want to handle reconnects &/or retries here?
             return new Promise(resolve =>
                 setTimeout(async () => {

--- a/src/rabbit-event-bus/amqp-connector.ts
+++ b/src/rabbit-event-bus/amqp-connector.ts
@@ -16,14 +16,14 @@ export default class AMQPConnector {
     private destroyed = false;
     private subscriptions: EventType[] = [];
 
-    public constructor([sender]: Channel<StateChange>, serviceName: string) {
+    public constructor(private readonly url: string, [sender]: Channel<StateChange>, serviceName: string) {
         this.externalConnector = { send: sender };
         this.serviceName = serviceName;
     }
 
-    public async setup(url: string, eventDefs: string[], subscriptions: Array<Subscription>): Promise<void> {
+    public async setup(eventDefs: string[], subscriptions: Array<Subscription>): Promise<void> {
         // Set up the connections to the AMQP server
-        return this.connect(url)
+        return this.connect(this.url)
             .then(async connection => {
                 this.connection = connection;
                 await this.setupExchanges(eventDefs, subscriptions);

--- a/src/rabbit-event-bus/index.test.ts
+++ b/src/rabbit-event-bus/index.test.ts
@@ -24,7 +24,7 @@ describe('AMQP Connection Manager', () => {
     describe('behaviour in a good connection state', () => {
         it('forwards messages to a connector', async () => {
             const publishMock = jest.fn(async () => true);
-            (AMQPConnector as jest.Mock).mockImplementation(([send]: Channel<StateChange>) => {
+            (AMQPConnector as jest.Mock).mockImplementation((_, [send]: Channel<StateChange>) => {
                 send({
                     newState: 'CONNECTED',
                 });
@@ -49,7 +49,7 @@ describe('AMQP Connection Manager', () => {
         it("passes on subscribes to the connector immediately, while it's ready", async () => {
             const subscribeMock = jest.fn();
             const [readyNotify, readyWait] = channel<{}>();
-            (AMQPConnector as jest.Mock).mockImplementation(([send]: Channel<StateChange>) => {
+            (AMQPConnector as jest.Mock).mockImplementation((_, [send]: Channel<StateChange>) => {
                 send({
                     newState: 'CONNECTED',
                 });
@@ -77,7 +77,7 @@ describe('AMQP Connection Manager', () => {
             // This channel is used to simulate startup delay in the connector
             const [readyNotify, readyWait] = channel<{}>();
 
-            (AMQPConnector as jest.Mock).mockImplementation(([send]: Channel<StateChange>) => {
+            (AMQPConnector as jest.Mock).mockImplementation((_, [send]: Channel<StateChange>) => {
                 send({
                     newState: 'CONNECTED',
                 });
@@ -135,7 +135,7 @@ describe('AMQP Connection Manager', () => {
             // This channel is used to simulate startup delay in the connector
             const [readyNotify, readyWait] = channel<{}>();
 
-            (AMQPConnector as jest.Mock).mockImplementation(([send]: Channel<StateChange>) => {
+            (AMQPConnector as jest.Mock).mockImplementation((_, [send]: Channel<StateChange>) => {
                 send({
                     newState: 'CONNECTED',
                 });
@@ -180,7 +180,7 @@ describe('AMQP Connection Manager', () => {
 
             (AMQPConnector as jest.Mock).mockImplementation(
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                ([send, _1]: Channel<StateChange>) => {
+                (_, [send, _1]: Channel<StateChange>) => {
                     send({
                         newState: 'NOT_CONNECTED',
                     });
@@ -234,7 +234,7 @@ describe('AMQP Connection Manager', () => {
         it('publish promises are resolved after a successful connection', async done => {
             const subscribeMock = jest.fn();
 
-            (AMQPConnector as jest.Mock).mockImplementation(([send]: Channel<StateChange>) => {
+            (AMQPConnector as jest.Mock).mockImplementation((_, [send]: Channel<StateChange>) => {
                 send({
                     newState: 'CONNECTED',
                 });
@@ -289,7 +289,7 @@ describe('AMQP Connection Manager', () => {
             let returnState: ConnectedState = 'NOT_CONNECTED';
             let returnPublish = false;
 
-            (AMQPConnector as jest.Mock).mockImplementation(([send]: Channel<StateChange>) => {
+            (AMQPConnector as jest.Mock).mockImplementation((_, [send]: Channel<StateChange>) => {
                 send({
                     newState: returnState,
                 });

--- a/src/rabbit-event-bus/index.test.ts
+++ b/src/rabbit-event-bus/index.test.ts
@@ -11,9 +11,10 @@ describe('AMQP Connection Manager', () => {
     describe('destroy', () => {
         it('calls connector destroy method', async () => {
             const destroyMock = jest.fn();
-            (AMQPConnector as jest.Mock).mockImplementation(() => ({ destroy: destroyMock }));
-            const manager = await new RabbitEventBus({ url: '' }, [], '');
-
+            const setupMock = jest.fn();
+            (AMQPConnector as jest.Mock).mockImplementation(() => ({ destroy: destroyMock, setup: setupMock }));
+            const manager = new RabbitEventBus({ url: '' }, [], '');
+            await manager.connect();
             await manager.destroy();
 
             expect(destroyMock).toHaveBeenCalledTimes(1);
@@ -23,16 +24,18 @@ describe('AMQP Connection Manager', () => {
     describe('behaviour in a good connection state', () => {
         it('forwards messages to a connector', async () => {
             const publishMock = jest.fn(async () => true);
-            (AMQPConnector as jest.Mock).mockImplementation((__, [send]: Channel<StateChange>) => {
+            (AMQPConnector as jest.Mock).mockImplementation(([send]: Channel<StateChange>) => {
                 send({
                     newState: 'CONNECTED',
                 });
                 return {
+                    setup: jest.fn(),
                     publish: publishMock,
                     subscribe: jest.fn(),
                 };
             });
             const manager = await new RabbitEventBus({ url: '' }, [], '');
+            await manager.connect();
             await manager.publish({
                 eventType: 'test',
                 id: 'something',
@@ -46,7 +49,7 @@ describe('AMQP Connection Manager', () => {
         it("passes on subscribes to the connector immediately, while it's ready", async () => {
             const subscribeMock = jest.fn();
             const [readyNotify, readyWait] = channel<{}>();
-            (AMQPConnector as jest.Mock).mockImplementation((__, [send]: Channel<StateChange>) => {
+            (AMQPConnector as jest.Mock).mockImplementation(([send]: Channel<StateChange>) => {
                 send({
                     newState: 'CONNECTED',
                 });
@@ -54,12 +57,14 @@ describe('AMQP Connection Manager', () => {
                 readyNotify({});
                 return {
                     publish: jest.fn(),
+                    setup: jest.fn(),
                     subscribe: subscribeMock,
                 };
             });
 
             const manager = await new RabbitEventBus({ url: '' }, [], '');
 
+            await manager.connect();
             await manager.subscribe('test', jest.fn());
 
             await readyWait();
@@ -72,7 +77,7 @@ describe('AMQP Connection Manager', () => {
             // This channel is used to simulate startup delay in the connector
             const [readyNotify, readyWait] = channel<{}>();
 
-            (AMQPConnector as jest.Mock).mockImplementation((___, [send]: Channel<StateChange>, __, subscriptions) => {
+            (AMQPConnector as jest.Mock).mockImplementation(([send]: Channel<StateChange>) => {
                 send({
                     newState: 'CONNECTED',
                 });
@@ -82,13 +87,14 @@ describe('AMQP Connection Manager', () => {
                     });
                 });
                 return {
-                    subscriptions,
+                    setup: jest.fn(),
                     publish: publishMock,
                     subscribe: jest.fn(),
                 };
             });
 
             const manager = await new RabbitEventBus({ url: '' }, [], '');
+            await manager.connect();
 
             Promise.all([
                 manager.publish({
@@ -129,7 +135,7 @@ describe('AMQP Connection Manager', () => {
             // This channel is used to simulate startup delay in the connector
             const [readyNotify, readyWait] = channel<{}>();
 
-            (AMQPConnector as jest.Mock).mockImplementation((__, [send]: Channel<StateChange>, _2, subscriptions) => {
+            (AMQPConnector as jest.Mock).mockImplementation(([send]: Channel<StateChange>) => {
                 send({
                     newState: 'CONNECTED',
                 });
@@ -139,14 +145,15 @@ describe('AMQP Connection Manager', () => {
                     });
                 });
                 return {
-                    subscriptions,
                     connect: connectMock,
                     publish: jest.fn(),
+                    setup: jest.fn(),
                     subscribe: subscribeMock,
                 };
             });
 
             const manager = await new RabbitEventBus({ url: '' }, [], '');
+            await manager.connect();
 
             await manager.subscribe('test', jest.fn());
             await manager.subscribe('test', jest.fn());
@@ -173,21 +180,22 @@ describe('AMQP Connection Manager', () => {
 
             (AMQPConnector as jest.Mock).mockImplementation(
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                (_0, [send, _1]: Channel<StateChange>, _2, subscriptions) => {
+                ([send, _1]: Channel<StateChange>) => {
                     send({
                         newState: 'NOT_CONNECTED',
                     });
 
                     return {
-                        subscriptions,
                         connect: connectMock,
                         publish: jest.fn(() => false),
+                        setup: jest.fn(),
                         subscribe: subscribeMock,
                     };
                 },
             );
 
             const manager = await new RabbitEventBus({ url: '' }, [], '');
+            await manager.connect();
             const then = jest.fn();
 
             manager
@@ -226,19 +234,20 @@ describe('AMQP Connection Manager', () => {
         it('publish promises are resolved after a successful connection', async done => {
             const subscribeMock = jest.fn();
 
-            (AMQPConnector as jest.Mock).mockImplementation((__, [send]: Channel<StateChange>, _2, subscriptions) => {
+            (AMQPConnector as jest.Mock).mockImplementation(([send]: Channel<StateChange>) => {
                 send({
                     newState: 'CONNECTED',
                 });
 
                 return {
-                    subscriptions,
                     publish: jest.fn(() => true),
                     subscribe: subscribeMock,
+                    setup: jest.fn(),
                 };
             });
 
             const manager = await new RabbitEventBus({ url: '' }, [], '');
+            await manager.connect();
             const then = jest.fn();
 
             manager
@@ -280,20 +289,21 @@ describe('AMQP Connection Manager', () => {
             let returnState: ConnectedState = 'NOT_CONNECTED';
             let returnPublish = false;
 
-            (AMQPConnector as jest.Mock).mockImplementation((__, [send]: Channel<StateChange>, _2, subscriptions) => {
+            (AMQPConnector as jest.Mock).mockImplementation(([send]: Channel<StateChange>) => {
                 send({
                     newState: returnState,
                 });
 
                 return {
-                    subscriptions,
                     connect: connectMock,
                     publish: jest.fn(() => returnPublish),
                     subscribe: subscribeMock,
+                    setup: jest.fn(),
                 };
             });
 
             const manager = await new RabbitEventBus({ url: '' }, [], '');
+            manager.connect();
             const then = jest.fn();
 
             manager

--- a/src/rabbit-event-bus/index.ts
+++ b/src/rabbit-event-bus/index.ts
@@ -65,10 +65,10 @@ export default class RabbitEventBus extends EventBus implements EventPublisher, 
     }
 
     public async connect(): Promise<void> {
-        this._connector = Some(new AMQPConnector(this.connection.channel, this.serviceName));
+        this._connector = Some(new AMQPConnector(this.url, this.connection.channel, this.serviceName));
 
         if (!this._connector.isEmpty()) {
-            await this._connector.get().setup(this.url, this.eventsToHandle, this.subscriptions);
+            await this._connector.get().setup(this.eventsToHandle, this.subscriptions);
         }
     }
 


### PR DESCRIPTION
Closes #19 

The current connection logic introduces a race condition when the consuming app calls subscribe or publish while its connecting.